### PR TITLE
Exploit fixes

### DIFF
--- a/Source/ShootThemUp/Private/Components/STUHealthActorComponent.cpp
+++ b/Source/ShootThemUp/Private/Components/STUHealthActorComponent.cpp
@@ -152,7 +152,7 @@ void USTUHealthActorComponent::OnTakePointDamage(AActor *DamagedActor, float Dam
                                                  FName BoneName, FVector ShotFromDirection,
                                                  const UDamageType *DamageType, AActor *DamageCauser)
 {
-    if (!DamagedActor)
+    if (!DamagedActor || !GetOwner() || !InstigatedBy)
         return;
     const auto FinalDamage = Damage * GetPointDamageModifier(DamagedActor, BoneName);
     UE_LOG(LogHealthComponent, Display, TEXT("On point damage: %f, final: %f, bone: %s"), Damage, FinalDamage,

--- a/Source/ShootThemUp/Private/Components/STUWeaponComponent.cpp
+++ b/Source/ShootThemUp/Private/Components/STUWeaponComponent.cpp
@@ -204,6 +204,10 @@ void USTUWeaponComponent::EndPlay(const EEndPlayReason::Type EndPlayReason)
     CurrentWeapon = nullptr;
     for (auto Weapon : Weapons)
     {
+        if (!Weapon)
+            continue;
+            
+        
         Weapon->DetachFromActor(FDetachmentTransformRules::KeepRelativeTransform);
         Weapon->Destroy();
     }

--- a/Source/ShootThemUp/Private/Player/STUPlayerController.cpp
+++ b/Source/ShootThemUp/Private/Player/STUPlayerController.cpp
@@ -137,7 +137,17 @@ void ASTUPlayerController::BeginPlay()
             if (Cameras.IsEmpty() || !Cameras[0])
                 return;
 
-            SetViewTarget(Cameras[0]);
+            for (AActor *Camera : Cameras)
+            {
+                if (Camera->Tags.Contains("LobbyCamera")) // or check by name
+                {
+                    if (IsLocalController())
+                    {
+                        SetViewTarget(Cameras[0]);
+                    }
+                    break;
+                }
+            }
         }
         
     }

--- a/Source/ShootThemUp/Private/Weapon/STUProjectile.cpp
+++ b/Source/ShootThemUp/Private/Weapon/STUProjectile.cpp
@@ -9,7 +9,7 @@
 #include "Kismet/GameplayStatics.h"
 #include "Sound/SoundCue.h"
 #include "Weapon/Components/STUWeaponFXComponent.h"
-
+#include "STUUtils.h"
 #include "Engine/DamageEvents.h"
 ASTUProjectile::ASTUProjectile()
 {
@@ -69,42 +69,16 @@ void ASTUProjectile::OnProjectileHit(UPrimitiveComponent *HitComponent, AActor *
                                             UDamageType::StaticClass(), {}, this, GetController(), DoFullDamage);
     }*/
 
-    TArray<FOverlapResult> Overlaps;
-    TArray<AActor*> FinishedActors;
-    FCollisionShape Sphere = FCollisionShape::MakeSphere(DamageRadius);
-    if (GetWorld()->OverlapMultiByChannel(Overlaps, GetActorLocation(), FQuat::Identity, ECC_PhysicsBody, Sphere))
-    {
-        for (auto &Result : Overlaps)
-        {
-            UPrimitiveComponent *OverlappedComp = Result.GetComponent();
-            AActor *OverlappedActor = Result.GetActor();
-            if (FinishedActors.Contains(OverlappedActor))
-                continue;
+    FExplosionParams ExplosionParams;
+    ExplosionParams.DamageRadius = DamageRadius;
+    ExplosionParams.DamageAmount = DamageAmount;
+    ExplosionParams.DamageAmountMin = DamageAmountMin;
+    ExplosionParams.ExplosionStrength = ExplosionStrength;
+    ExplosionParams.ExplosionStrengthMin = ExplosionStrengthMin;
 
-            if (ACharacter *HitCharacter = Cast<ACharacter>(OverlappedActor))
-            {
-                FVector Direction = HitCharacter->GetActorLocation() - GetActorLocation();
-                float Damage = FMath::GetMappedRangeValueClamped(FVector2D(0.f, DamageRadius), FVector2D(DamageAmount, DamageAmountMin), Direction.Size());
-                FPointDamageEvent DEvent;
-                DEvent.DamageTypeClass = UDamageType::StaticClass();
-                HitCharacter->TakeDamage(Damage, DEvent, Cast<ACharacter>(GetOwner())->Controller, this);
-                float ExplosionStrengthMapped = FMath::GetMappedRangeValueClamped(
-                    FVector2D(0.f, DamageRadius), FVector2D(ExplosionStrength, ExplosionStrengthMin), Direction.Size());
-                
-                Direction.Normalize();
-                FVector LaunchVelocity = Direction * ExplosionStrengthMapped;
-                LaunchVelocity.Z += ExplosionStrengthMapped/3;
-
-                HitCharacter->LaunchCharacter(LaunchVelocity, true, true);
-            }
-            else if (OverlappedComp && OverlappedComp->IsSimulatingPhysics())
-            {
-                OverlappedComp->AddRadialImpulse(GetActorLocation(), DamageRadius, ExplosionStrength,
-                                                 ERadialImpulseFalloff::RIF_Linear, true);
-            }
-            FinishedActors.Add(OverlappedActor);
-        }
-    }
+    STUUtils::ApplyRadialDamageWithLineOfSight(GetWorld(), GetActorLocation(), ExplosionParams, this,
+                                               Cast<ACharacter>(GetOwner())->Controller,
+                                               {this});
 
     Destroy();
 }

--- a/Source/ShootThemUp/Private/Weapon/STUProjectile.cpp
+++ b/Source/ShootThemUp/Private/Weapon/STUProjectile.cpp
@@ -70,6 +70,7 @@ void ASTUProjectile::OnProjectileHit(UPrimitiveComponent *HitComponent, AActor *
     }*/
 
     TArray<FOverlapResult> Overlaps;
+    TArray<AActor*> FinishedActors;
     FCollisionShape Sphere = FCollisionShape::MakeSphere(DamageRadius);
     if (GetWorld()->OverlapMultiByChannel(Overlaps, GetActorLocation(), FQuat::Identity, ECC_PhysicsBody, Sphere))
     {
@@ -77,20 +78,22 @@ void ASTUProjectile::OnProjectileHit(UPrimitiveComponent *HitComponent, AActor *
         {
             UPrimitiveComponent *OverlappedComp = Result.GetComponent();
             AActor *OverlappedActor = Result.GetActor();
+            if (FinishedActors.Contains(OverlappedActor))
+                continue;
 
             if (ACharacter *HitCharacter = Cast<ACharacter>(OverlappedActor))
             {
                 FVector Direction = HitCharacter->GetActorLocation() - GetActorLocation();
-                float Damage = FMath::GetMappedRangeValueClamped(FVector2D(0.f, DamageRadius+100.f),
-                                                                 FVector2D(DamageAmount, 0.f), Direction.Size());
+                float Damage = FMath::GetMappedRangeValueClamped(FVector2D(0.f, DamageRadius), FVector2D(DamageAmount, DamageAmountMin), Direction.Size());
                 FPointDamageEvent DEvent;
                 DEvent.DamageTypeClass = UDamageType::StaticClass();
                 HitCharacter->TakeDamage(Damage, DEvent, Cast<ACharacter>(GetOwner())->Controller, this);
-
+                float ExplosionStrengthMapped = FMath::GetMappedRangeValueClamped(
+                    FVector2D(0.f, DamageRadius), FVector2D(ExplosionStrength, ExplosionStrengthMin), Direction.Size());
+                
                 Direction.Normalize();
-
-                FVector LaunchVelocity = Direction * ExplosionStrength;
-                LaunchVelocity.Z += 300.0f;
+                FVector LaunchVelocity = Direction * ExplosionStrengthMapped;
+                LaunchVelocity.Z += ExplosionStrengthMapped/3;
 
                 HitCharacter->LaunchCharacter(LaunchVelocity, true, true);
             }
@@ -99,6 +102,7 @@ void ASTUProjectile::OnProjectileHit(UPrimitiveComponent *HitComponent, AActor *
                 OverlappedComp->AddRadialImpulse(GetActorLocation(), DamageRadius, ExplosionStrength,
                                                  ERadialImpulseFalloff::RIF_Linear, true);
             }
+            FinishedActors.Add(OverlappedActor);
         }
     }
 

--- a/Source/ShootThemUp/Public/STUCoreTypes.h
+++ b/Source/ShootThemUp/Public/STUCoreTypes.h
@@ -246,3 +246,14 @@ enum class STUPlayerStateEnum : uint8
     Spectating
 };
 
+USTRUCT()
+struct FExplosionParams
+{
+    GENERATED_BODY()
+
+    float DamageRadius = 300.0f;
+    float DamageAmount = 100.0f;
+    float DamageAmountMin = 10.0f;
+    float ExplosionStrength = 1000.0f;
+    float ExplosionStrengthMin = 100.0f;
+};

--- a/Source/ShootThemUp/Public/STUUtils.h
+++ b/Source/ShootThemUp/Public/STUUtils.h
@@ -1,7 +1,14 @@
 ﻿#pragma once
 #include "Player/STUPlayerState.h"
-#include "STUGameInstance.h"
+
+#include "Components/PrimitiveComponent.h"
+#include "CoreMinimal.h"
+#include "Engine/DamageEvents.h"
+#include "Engine/World.h"
+#include "GameFramework/Character.h"
+#include "GameFramework/Controller.h"
 #include "STUCoreTypes.h"
+#include "STUGameInstance.h"
 
 class STUUtils
 {
@@ -14,7 +21,7 @@ class STUUtils
         const auto Component = PlayerPawn->GetComponentByClass(T::StaticClass());
         return Cast<T>(Component);
     }
-    bool static AreEnemies(AController* Controller1, AController* Controller2) 
+    bool static AreEnemies(AController *Controller1, AController *Controller2)
     {
         if (!Controller1 || !Controller2 || Controller1 == Controller2)
             return false;
@@ -54,18 +61,18 @@ class STUUtils
 
         return nullptr;
     }
-   /* FPlayerInfo static GetPlayerStatsFromPlayerState(ASTUPlayerState* PlayerState)
-    {
-        FPlayerInfo NewPlayerStats;
-        if (!PlayerState)
-            return NewPlayerStats;
-        NewPlayerStats.PlayerName = PlayerState->GetPlayerName();
-        NewPlayerStats.Kills = PlayerState->GetKillsNum();
-        NewPlayerStats.Deaths = PlayerState->GetDeathsNum();
-        NewPlayerStats.TeamID = PlayerState->GetTeamID();
-        NewPlayerStats.TeamColor = PlayerState->GetTeamColor();
-        return NewPlayerStats;
-    }*/
+    /* FPlayerInfo static GetPlayerStatsFromPlayerState(ASTUPlayerState* PlayerState)
+     {
+         FPlayerInfo NewPlayerStats;
+         if (!PlayerState)
+             return NewPlayerStats;
+         NewPlayerStats.PlayerName = PlayerState->GetPlayerName();
+         NewPlayerStats.Kills = PlayerState->GetKillsNum();
+         NewPlayerStats.Deaths = PlayerState->GetDeathsNum();
+         NewPlayerStats.TeamID = PlayerState->GetTeamID();
+         NewPlayerStats.TeamColor = PlayerState->GetTeamColor();
+         return NewPlayerStats;
+     }*/
     FStatRowInfo static GetStatRowInfoFromFPlayerStats(FPlayerInfo &PlayerInfo)
     {
         FStatRowInfo RowInfo;
@@ -95,5 +102,69 @@ class STUUtils
             }
         }
         return nullptr;
+    }
+
+    static void ApplyRadialDamageWithLineOfSight(UWorld *World, const FVector &Origin, const FExplosionParams &Params,
+                                                 AActor *DamageCauser, AController *InstigatorController,
+                                                 const TArray<AActor *> &IgnoredActors)
+    {
+        if (!World)
+            return;
+
+        TArray<FOverlapResult> Overlaps;
+        TArray<AActor *> FinishedActors;
+        FCollisionShape Sphere = FCollisionShape::MakeSphere(Params.DamageRadius);
+
+        if (World->OverlapMultiByChannel(Overlaps, Origin, FQuat::Identity, ECC_PhysicsBody, Sphere))
+        {
+            for (auto &Result : Overlaps)
+            {
+                UPrimitiveComponent *OverlappedComp = Result.GetComponent();
+                AActor *OverlappedActor = Result.GetActor();
+                if (!OverlappedActor || FinishedActors.Contains(OverlappedActor))
+                    continue;
+
+                // Line of sight check
+                FHitResult HitResult;
+                FCollisionQueryParams QueryParams;
+                QueryParams.AddIgnoredActor(DamageCauser);
+                QueryParams.AddIgnoredActor(OverlappedActor);
+                for (AActor *Actor : IgnoredActors)
+                {
+                    QueryParams.AddIgnoredActor(Actor);
+                }
+
+                bool bHit = World->LineTraceSingleByChannel(HitResult, Origin, OverlappedActor->GetActorLocation(),
+                                                            ECC_Visibility, QueryParams);
+                if (bHit)
+                    continue;
+
+                if (ACharacter *HitCharacter = Cast<ACharacter>(OverlappedActor))
+                {
+                    FVector Direction = HitCharacter->GetActorLocation() - Origin;
+                    float Damage = FMath::GetMappedRangeValueClamped(
+                        FVector2D(0.f, Params.DamageRadius), FVector2D(Params.DamageAmount, Params.DamageAmountMin),
+                        Direction.Size());
+                    FPointDamageEvent DEvent;
+                    DEvent.DamageTypeClass = UDamageType::StaticClass();
+                    HitCharacter->TakeDamage(Damage, DEvent, InstigatorController, DamageCauser);
+
+                    float ExplosionStrengthMapped = FMath::GetMappedRangeValueClamped(
+                        FVector2D(0.f, Params.DamageRadius),
+                        FVector2D(Params.ExplosionStrength, Params.ExplosionStrengthMin), Direction.Size());
+
+                    Direction.Normalize();
+                    FVector LaunchVelocity = Direction * ExplosionStrengthMapped;
+                    LaunchVelocity.Z += ExplosionStrengthMapped / 3;
+                    HitCharacter->LaunchCharacter(LaunchVelocity, true, true);
+                }
+                else if (OverlappedComp && OverlappedComp->IsSimulatingPhysics())
+                {
+                    OverlappedComp->AddRadialImpulse(Origin, Params.DamageRadius, Params.ExplosionStrength,
+                                                     ERadialImpulseFalloff::RIF_Linear, true);
+                }
+                FinishedActors.Add(OverlappedActor);
+            }
+        }
     }
 };

--- a/Source/ShootThemUp/Public/Weapon/STUProjectile.h
+++ b/Source/ShootThemUp/Public/Weapon/STUProjectile.h
@@ -37,11 +37,15 @@ protected:
   UPROPERTY(EditDefaultsOnly, Category = "Stat")
   float DamageAmount = 50.0f;
   UPROPERTY(EditDefaultsOnly, Category = "Stat")
+  float DamageAmountMin = 30.0f;
+  UPROPERTY(EditDefaultsOnly, Category = "Stat")
   bool DoFullDamage = false;
   UPROPERTY(EditDefaultsOnly, Category = "Stat")
   float LifeSeconds = 5.0f;
   UPROPERTY(EditDefaultsOnly, BlueprintReadWrite, Category = "Stat")
   float ExplosionStrength = 1000.0f;
+  UPROPERTY(EditDefaultsOnly, BlueprintReadWrite, Category = "Stat")
+  float ExplosionStrengthMin = 300.0f;
   UPROPERTY(VisibleAnywhere, Category = "VFX")
   USTUWeaponFXComponent *WeaponFXComponent;
   UPROPERTY(EditDefaultsOnly, Category = "Sound")

--- a/enc_temp_folder/ae54779fe602fe0f53b75c5e188b93/STUBaseCharacter.cpp
+++ b/enc_temp_folder/ae54779fe602fe0f53b75c5e188b93/STUBaseCharacter.cpp
@@ -71,10 +71,8 @@ void ASTUBaseCharacter::InitPlayer()
     {
         return;
     }
-    if (!GetWorld()->GetFirstPlayerController() || !GetWorld()->GetFirstPlayerController()->PlayerState)
-    {
-        return;
-    }
+    UE_LOG(BaseCharacterLog, Display, TEXT("Am I need to Possess? My %s FirstPC %s"), *PlayerID,
+           *GetWorld()->GetFirstPlayerController()->PlayerState->GetUniqueId()->ToString());
     if (PlayerID == GetWorld()->GetFirstPlayerController()->PlayerState->GetUniqueId()->ToString())
     {
         UE_LOG(BaseCharacterLog, Display, TEXT("Yes! Requesting possess now"));


### PR DESCRIPTION
Various exploit and bug fixes.
Small code improvements.

[Fixed Launcher and point damage](https://github.com/1Laggy1/ShootThemUp/commit/c3484241086b0622dc034349f8ce8b63dd03b692)

- Added nullptr check to OnTakePointDamage in STUHealthActorComponent that was causing crash.
- Changed STUProjectile to insure that damage on one actor will apply only once. Previously something was causing multiple damage applies and because of that more damage was taken by the players. Also now damage will be not 0 if you hit player on max distance, this was causing players thinking that they hit the player, but no damage was applied. Also because of the same issue I made Explosion velocity strength to be mapped too.
- Fixed that you could grab a ball, and because of no physics on ball when you carrying it, you could use launcher to fly to your goal, go around the map, and goal to the enemy team from the other side.

[Camera fix](https://github.com/1Laggy1/ShootThemUp/commit/f491ecd6b928dc5fd38cc46acd26cbf69df853fd)
- Trying to fix camera going right again. Add tag to the lobby camera, and checking that I got right camera

[Code improvements](https://github.com/1Laggy1/ShootThemUp/commit/477b169d3b58e8c71e1a569e5a078fa50b3d80bf)
- STUProjectile added line of site check.
- STUProjectile on hit was very complex, and I will need this explosion code in other places, so I moved this logic to STUUtils, and created FExplosionParams in STUCoreTypes.
- STUBaseCharacter added nullptr check for PlayerState.